### PR TITLE
♻️ refactor (86a7w2t44): Replacing cookies with authorization header

### DIFF
--- a/src/application/dtos/auth.dto.ts
+++ b/src/application/dtos/auth.dto.ts
@@ -30,5 +30,6 @@ export const JwtTokensSchema = Type.Object({
   accessToken: Type.String(),
   refreshToken: Type.String(),
   userType: Type.String(),
+  userId: Type.String(),
 });
 export type JwtTokensDto = Static<typeof JwtTokensSchema>;

--- a/src/application/services/auth.service.ts
+++ b/src/application/services/auth.service.ts
@@ -33,6 +33,7 @@ export class AuthService {
       accessToken,
       refreshToken,
       userType: user.userType,
+      userId: user.id,
     };
   }
 
@@ -57,16 +58,19 @@ export class AuthService {
         accessToken: newAccessToken,
         refreshToken,
         userType: decoded.type,
+        userId: decoded.id,
       };
     } catch (error) {
       throw new Error((error as Error).message);
     }
   }
 
-  public async getSession(token: string): Promise<{ userType: string }> {
+  public async getSession(
+    token: string,
+  ): Promise<{ userType: string; userId: string }> {
     try {
       const decoded: any = jwt.verify(token, config.jwt.secret);
-      return { userType: decoded.type };
+      return { userType: decoded.type, userId: decoded.id };
     } catch {
       throw new Error('Token inválido o expirado');
     }

--- a/src/presentation/controllers/auth.controller.ts
+++ b/src/presentation/controllers/auth.controller.ts
@@ -7,52 +7,28 @@ import {
 import { LoginDto } from '../../application/dtos/auth.dto';
 import { AuthService } from '../../application/services/auth.service';
 import { UserRepository } from '../../infrastructure';
-import config from '../../infrastructure/config';
 
 export class AuthController {
-  private authService: AuthService;
-  private loginUseCase: LoginUseCase;
-  private refreshTokenUseCase: RefreshTokenUseCase;
-  private getSessionUseCase: GetSessionUseCase;
+  private readonly loginUseCase: LoginUseCase;
+  private readonly refreshTokenUseCase: RefreshTokenUseCase;
+  private readonly getSessionUseCase: GetSessionUseCase;
 
   constructor() {
-    this.authService = new AuthService(new UserRepository());
-    this.loginUseCase = new LoginUseCase(this.authService);
-    this.refreshTokenUseCase = new RefreshTokenUseCase(this.authService);
-    this.getSessionUseCase = new GetSessionUseCase(this.authService);
-  }
-
-  private setAuthCookies(
-    res: Response,
-    accessToken: string,
-    refreshToken: string,
-  ): void {
-    const accessTokenMaxAge = config.jwt.tokenExpiresIn * 1000;
-    const refreshTokenMaxAge = config.jwt.refreshExpiresTokenIn * 1000;
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-
-      sameSite: 'lax',
-      maxAge: accessTokenMaxAge,
-    });
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: refreshTokenMaxAge,
-    });
+    const authService = new AuthService(new UserRepository());
+    this.loginUseCase = new LoginUseCase(authService);
+    this.refreshTokenUseCase = new RefreshTokenUseCase(authService);
+    this.getSessionUseCase = new GetSessionUseCase(authService);
   }
 
   public async login(req: Request, res: Response): Promise<void> {
     const loginDto: LoginDto = req.body;
     try {
       const tokens = await this.loginUseCase.execute(loginDto);
-      this.setAuthCookies(res, tokens.accessToken, tokens.refreshToken);
+      // Devolvemos ambos tokens en el body
       res.status(200).json({
         message: 'Inicio de sesión exitoso',
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
         userType: tokens.userType,
       });
     } catch (error: unknown) {
@@ -64,20 +40,22 @@ export class AuthController {
     }
   }
 
-  //para produccion
   public async refreshToken(req: Request, res: Response): Promise<void> {
     try {
-      const refreshToken = req.cookies.refreshToken;
-      if (!refreshToken) {
+      const authHeader = req.headers.authorization;
+      if (!authHeader?.startsWith('Bearer ')) {
         res
           .status(401)
-          .json({ message: 'No se encontró el token de actualización' });
+          .json({ message: 'No se proporcionó un token Bearer válido' });
         return;
       }
+      const refreshToken = authHeader.slice(7).trim();
       const tokens = await this.refreshTokenUseCase.execute({ refreshToken });
-      this.setAuthCookies(res, tokens.accessToken, tokens.refreshToken);
+      // Devolvemos los nuevos tokens
       res.status(200).json({
         message: 'Tokens renovados correctamente',
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
         userType: tokens.userType,
       });
     } catch (error: unknown) {
@@ -91,16 +69,20 @@ export class AuthController {
 
   public async getSession(req: Request, res: Response): Promise<void> {
     try {
-      const token = req.cookies.accessToken;
-      if (!token) {
-        res.status(401).json({ message: 'No se encontró token de acceso' });
+      const authHeader = req.headers.authorization;
+      if (!authHeader?.startsWith('Bearer ')) {
+        res
+          .status(401)
+          .json({ message: 'No se encontró token de acceso en Authorization' });
         return;
       }
-      const session = await this.getSessionUseCase.execute(token);
+      const accessToken = authHeader.slice(7).trim();
+      const session = await this.getSessionUseCase.execute(accessToken);
       res.status(200).json({ userType: session.userType });
     } catch (error: unknown) {
       if (error instanceof Error) {
         res.status(401).json({ message: error.message });
+        console.log('Error en getSession:', error.message);
       } else {
         res.status(500).json({ message: 'Error desconocido' });
       }
@@ -108,8 +90,7 @@ export class AuthController {
   }
 
   public async logout(req: Request, res: Response): Promise<void> {
-    res.clearCookie('accessToken');
-    res.clearCookie('refreshToken');
+    // Como no hay cookies, el cliente debe borrar sus tokens localmente
     res.status(200).json({ message: 'Sesión cerrada correctamente' });
   }
 }

--- a/src/presentation/routes/major.router.ts
+++ b/src/presentation/routes/major.router.ts
@@ -30,7 +30,7 @@ const majorController = new MajorController(
 // Defining routes with middleware validation and assigning controller methods
 router.get(
   '/',
-  validateRoleMiddleware(['STUDENT', 'ADMIN', 'INFOMANAGER' ]),
+  validateRoleMiddleware(['STUDENT', 'ADMIN', 'INFOMANAGER']),
   majorController.getAll,
 );
 router.get(
@@ -38,8 +38,16 @@ router.get(
   validateRoleMiddleware(['STUDENT', 'ADMIN', 'INFOMANAGER']),
   majorController.getById,
 );
-router.post('/', validateRoleMiddleware(['ADMIN', 'INFOMANAGER']), majorController.create);
-router.patch('/:id', validateRoleMiddleware(['ADMIN', 'INFOMANAGER']), majorController.update);
+router.post(
+  '/',
+  validateRoleMiddleware(['ADMIN', 'INFOMANAGER']),
+  majorController.create,
+);
+router.patch(
+  '/:id',
+  validateRoleMiddleware(['ADMIN', 'INFOMANAGER']),
+  majorController.update,
+);
 router.delete(
   '/:id',
   validateRoleMiddleware(['ADMIN', 'INFOMANAGER']),

--- a/src/tests/integration/crud/studentCrud.test.ts
+++ b/src/tests/integration/crud/studentCrud.test.ts
@@ -134,9 +134,7 @@ describe('Integration tests Student - CRUD', () => {
     expect(response.body);
   });
 
-  it('should recover password', async () => {
-    
-  })
+  it('should recover password', async () => {});
 
   it('should delete student acount', async () => {
     const response = await request(app)


### PR DESCRIPTION
## Description:
This PR refactors the authentication flow to use Bearer tokens in the Authorization header instead of HTTP-only cookies. All cookie-based logic has been removed from the controller, and endpoints now accept and return tokens via JSON payloads and headers. Clients are responsible for storing and sending tokens.

---

## Changes:

* AuthController.ts
Removed setAuthCookies and all cookie read/write logic.
Updated login to return accessToken and refreshToken in the JSON response.
Modified refreshToken to read a Bearer token from req.headers.authorization and return new tokens in the response body.
Updated getSession to extract the access token from the Authorization header.
Simplified logout to a stateless endpoint that only sends a confirmation message.

* Routes & Middleware
Adjusted any auth middleware or route definitions that previously relied on cookies to instead validate tokens from headers.