### PR TITLE
✨ Feature (86a88q99f): Enhance user deletion logic to support cascadi…

### DIFF
--- a/src/application/use-cases/user/delete-user.use-case.ts
+++ b/src/application/use-cases/user/delete-user.use-case.ts
@@ -1,9 +1,51 @@
-import { IUserRepository } from '../../../domain';
+// src/application/usecases/user/delete-user.usecase.ts
+import { IUserRepository } from '../../../domain/repositories/user.repository';
+import { UserResponseDto } from '../../dtos/';
 
 export class DeleteUserUseCase {
   constructor(private readonly userRepository: IUserRepository) {}
 
   public async execute(id: string): Promise<boolean> {
+    // 1. Recuperar al usuario para saber su tipo
+    const user: UserResponseDto | null = await this.userRepository.findById(id);
+    if (!user) return false;
+    const { userType } = user;
+
+    // 2. Borrado en cascada según rol
+    switch (userType) {
+      case 'TUTOR': {
+        const students = await this.userRepository.findStudentsByTutor(id);
+        await Promise.all(
+          students.map((s) => this.userRepository.delete(s.id)),
+        );
+        break;
+      }
+      case 'UNIVERSITY': {
+        const infos =
+          await this.userRepository.findInfoManagersByUniversity(id);
+        const viewers = await this.userRepository.findViewersByUniversity(id);
+        await Promise.all([
+          ...infos.map((i) => this.userRepository.delete(i.id)),
+          ...viewers.map((v) => this.userRepository.delete(v.id)),
+        ]);
+        break;
+      }
+      case 'ADMIN': {
+        const marketers = await this.userRepository.findMarketersByAdmin(id);
+        const supports = await this.userRepository.findSupportsByAdmin(id);
+        const finances = await this.userRepository.findFinancesByAdmin(id);
+        await Promise.all([
+          ...marketers.map((m) => this.userRepository.delete(m.id)),
+          ...supports.map((s) => this.userRepository.delete(s.id)),
+          ...finances.map((f) => this.userRepository.delete(f.id)),
+        ]);
+        break;
+      }
+      default:
+        break;
+    }
+
+    // 3. Borrar al usuario “padre”
     return this.userRepository.delete(id);
   }
 }

--- a/src/presentation/controllers/user.controller.ts
+++ b/src/presentation/controllers/user.controller.ts
@@ -217,13 +217,17 @@ export class UserController {
   };
 
   public delete = async (
-    req: Request,
+    req: RequestWithUser,
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const { id } = req.params;
-      const deleted = await this.deleteUserUseCase.execute(id);
+      const userId = req.user?.id;
+      if (!userId) {
+        res.status(400).json({ message: 'User ID is missing' });
+        return;
+      }
+      const deleted = await this.deleteUserUseCase.execute(userId);
       if (!deleted) {
         res.status(404).json({ message: 'User not found' });
         return;

--- a/src/presentation/routes/user.router.ts
+++ b/src/presentation/routes/user.router.ts
@@ -180,8 +180,8 @@ router.patch(
 // Delete user by ID
 
 router.delete(
-  '/:id',
-  validateRoleMiddleware(['ADMIN', 'STUDENT', 'TUTOR', 'UNIVERSITY']),
+  '/',
+  validateRoleMiddleware(['ADMIN', 'TUTOR', 'UNIVERSITY']),
   userController.delete,
 );
 


### PR DESCRIPTION
**Pull Request Description**
This PR adds cascade delete support for root users (`ADMIN`, `TUTOR`, `UNIVERSITY`) and restricts access to the delete endpoint so that only those roles can invoke it. When a root user is deleted, all their associated child users (such as students, infoManagers, viewers, marketing, support, or finances) are deleted first to prevent orphaned data.

**Modified Files**

* `src/presentation/controllers/user.controller.ts`

  * Added role check to ensure only root users can perform deletions.
* `src/application/usecases/user/delete-user.usecase.ts`

  * Implemented cascade logic: fetch and delete all child users before deleting the root user.
