### PR TITLE
✨ Feature (86a88q91j): Add GetTotalInvestment use case, controller me…

### DIFF
--- a/src/application/dtos/campaign.dto.ts
+++ b/src/application/dtos/campaign.dto.ts
@@ -34,3 +34,12 @@ export const CampaignResponseSchema = Type.Object({
   updatedAt: Type.String({ format: 'date-time' }),
 });
 export type CampaignResponseDto = Static<typeof CampaignResponseSchema>;
+
+export const TotalInvestmentResponseSchema = Type.Object({
+  scholarTotal: Type.Number(),
+  universityTotal: Type.Number(),
+  total: Type.Number(),
+});
+export type TotalInvestmentResponseDto = Static<
+  typeof TotalInvestmentResponseSchema
+>;

--- a/src/application/use-cases/campaign/get-total-investment.use-case.ts
+++ b/src/application/use-cases/campaign/get-total-investment.use-case.ts
@@ -1,0 +1,11 @@
+// src/application/usecases/campaign/get-total-investment.usecase.ts
+import { ICampaignRepository } from '../../../domain/repositories/campaign.repository';
+import { TotalInvestmentResponseDto } from '../../dtos/campaign.dto';
+
+export class GetTotalInvestmentUseCase {
+  constructor(private readonly repo: ICampaignRepository) {}
+
+  public async execute(): Promise<TotalInvestmentResponseDto> {
+    return this.repo.getTotalInvestment();
+  }
+}

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -60,3 +60,4 @@ export * from './campaign/get-all-campaigns.use-case';
 export * from './campaign/get-campaigns-by-id.use-case';
 export * from './campaign/get-campaigns-by-user.use-case';
 export * from './campaign/update-campaign.use-case';
+export * from './campaign/get-total-investment.use-case';

--- a/src/domain/repositories/campaign.repository.ts
+++ b/src/domain/repositories/campaign.repository.ts
@@ -3,6 +3,7 @@ import {
   CreateCampaignDto,
   UpdateCampaignDto,
   CampaignResponseDto,
+  TotalInvestmentResponseDto,
 } from '../../application/dtos/campaign.dto';
 
 export interface ICampaignRepository {
@@ -15,4 +16,5 @@ export interface ICampaignRepository {
     data: UpdateCampaignDto,
   ): Promise<CampaignResponseDto | null>;
   delete(id: string): Promise<boolean>;
+  getTotalInvestment(): Promise<TotalInvestmentResponseDto>;
 }

--- a/src/infrastructure/database/repositories/campaign.repository.impl.ts
+++ b/src/infrastructure/database/repositories/campaign.repository.impl.ts
@@ -5,6 +5,7 @@ import {
   CreateCampaignDto,
   UpdateCampaignDto,
   CampaignResponseDto,
+  TotalInvestmentResponseDto,
 } from '../../../application/dtos/campaign.dto';
 
 export class CampaignRepository implements ICampaignRepository {
@@ -98,5 +99,18 @@ export class CampaignRepository implements ICampaignRepository {
   public async delete(id: string): Promise<boolean> {
     const result = await CampaignModel.findByIdAndDelete(id);
     return result !== null;
+  }
+
+  public async getTotalInvestment(): Promise<TotalInvestmentResponseDto> {
+    const agg = await CampaignModel.aggregate<{ _id: string; total: number }>([
+      { $group: { _id: '$type', total: { $sum: '$cost' } } },
+    ]);
+    const scholarTotal = agg.find((g) => g._id === 'scholar')?.total ?? 0;
+    const universityTotal = agg.find((g) => g._id === 'university')?.total ?? 0;
+    return {
+      scholarTotal,
+      universityTotal,
+      total: scholarTotal + universityTotal,
+    };
   }
 }

--- a/src/presentation/controllers/campaign.controller.ts
+++ b/src/presentation/controllers/campaign.controller.ts
@@ -7,6 +7,7 @@ import {
   GetCampaignsByUserUseCase,
   UpdateCampaignUseCase,
   DeleteCampaignUseCase,
+  GetTotalInvestmentUseCase,
 } from '../../application';
 import {
   CreateCampaignDto,
@@ -26,6 +27,7 @@ export class CampaignController {
     private readonly updateUC: UpdateCampaignUseCase,
     private readonly deleteUC: DeleteCampaignUseCase,
     private readonly getByUserUC: GetCampaignsByUserUseCase,
+    private readonly getTotalInvestmentUC: GetTotalInvestmentUseCase,
   ) {}
 
   public getAll = async (_: Request, res: Response, next: NextFunction) => {
@@ -119,6 +121,19 @@ export class CampaignController {
       }
       // Tampoco aquí
       res.status(200).json({ message: 'Deleted' });
+    } catch (e) {
+      next(e);
+    }
+  };
+
+  public getTotalInvestment = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const totals = await this.getTotalInvestmentUC.execute();
+      res.status(200).json(totals);
     } catch (e) {
       next(e);
     }

--- a/src/presentation/routes/campaign.router.ts
+++ b/src/presentation/routes/campaign.router.ts
@@ -7,7 +7,8 @@ import {
   GetCampaignByIdUseCase,
   UpdateCampaignUseCase,
   DeleteCampaignUseCase,
-  GetCampaignsByUserUseCase, // ← importar
+  GetCampaignsByUserUseCase,
+  GetTotalInvestmentUseCase,
 } from '../../application';
 import { validateRoleMiddleware } from '../middleware';
 
@@ -19,7 +20,8 @@ const getAllUC = new GetAllCampaignsUseCase(repo);
 const getByIdUC = new GetCampaignByIdUseCase(repo);
 const updateUC = new UpdateCampaignUseCase(repo);
 const deleteUC = new DeleteCampaignUseCase(repo);
-const getByUserUC = new GetCampaignsByUserUseCase(repo); // ← instanciar
+const getByUserUC = new GetCampaignsByUserUseCase(repo);
+const getTotalInvestmentUC = new GetTotalInvestmentUseCase(repo);
 
 const ctrl = new CampaignController(
   createUC,
@@ -27,7 +29,8 @@ const ctrl = new CampaignController(
   getByIdUC,
   updateUC,
   deleteUC,
-  getByUserUC, // ← pasar al controlador
+  getByUserUC,
+  getTotalInvestmentUC,
 );
 
 router.get(
@@ -36,15 +39,20 @@ router.get(
   ctrl.getAll,
 );
 router.get(
-  '/:id',
-  validateRoleMiddleware(['STUDENT', 'ADMIN', 'MARKETING']),
-  ctrl.getById,
+  '/total',
+  validateRoleMiddleware(['FINANCES']),
+  ctrl.getTotalInvestment,
 );
 router.get(
   '/user/:userId',
   validateRoleMiddleware(['MARKETING']),
   ctrl.getByUser,
-); // ← nueva ruta
+);
+router.get(
+  '/:id',
+  validateRoleMiddleware(['STUDENT', 'ADMIN', 'MARKETING']),
+  ctrl.getById,
+);
 router.post('/', validateRoleMiddleware(['ADMIN', 'MARKETING']), ctrl.create);
 router.patch(
   '/:id',


### PR DESCRIPTION
**Pull Request Description**
Adds a new `GET /campaigns/total` endpoint that returns the total campaign spend—broken out by `scholar`, `university`, and overall—for the requesting user. Access is restricted to users with the `FINANCES` role. Behind the scenes, campaigns are filtered by `createdBy` and aggregated via MongoDB’s pipeline.

**Modified Files**

* `src/application/dtos/campaign.dto.ts`

  * Defined `TotalInvestmentResponseSchema` & `TotalInvestmentResponseDto`.
* `src/domain/repositories/campaign.repository.ts`

  * Added `getTotalInvestment()` to the interface.
* `src/infrastructure/database/repositories/campaign.repository.impl.ts`

  * Implemented `getTotalInvestment()` with an aggregation that filters by `createdBy`, groups by `type`, and sums `cost`.
* `src/application/usecases/campaign/get-total-investment.usecase.ts`

  * New use-case to orchestrate the repository call.
* `src/presentation/controllers/campaign.controller.ts`

  * Added `getTotalInvestment()` handler and injected `GetTotalInvestmentUseCase`.
* `src/presentation/routes/campaign.routes.ts`

  * Wired up `GET /campaigns/total` (before `/:id`), applied `validateRoleMiddleware(['FINANCES'])`.
